### PR TITLE
fix: TraceOutput.file can be None

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,19 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
+  
+  keke-types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+      - name: Set Up Virtualenv
+        run: |
+          python -m pip install --upgrade pip
+          make venv
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - uses: jakebailey/pyright-action@v2
+        with:
+          version: PATH

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 	python -m ufmt check $(SOURCES)
 	python -m flake8 $(SOURCES)
 	python -m checkdeps --allow-names keke keke
-	mypy --strict --install-types --non-interactive keke
+	pyright keke
 
 .PHONY: release
 release:

--- a/keke/__init__.py
+++ b/keke/__init__.py
@@ -52,7 +52,7 @@ def to_microseconds(s: float) -> float:
 class TraceOutput:
     def __init__(
         self,
-        file: IO[str],
+        file: Optional[IO[str]],
         # These sort key substrings are neat and work in chrome://tracing but
         # notably do _not_ work in perfetto when using json input.
         # https://groups.google.com/g/perfetto-dev/c/zOe_Y2FxGGk

--- a/keke/pyrightconfig.json
+++ b/keke/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "pythonVersion": "3.7",
+    "typeCheckingMode": "strict"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ dev =
     black == 24.2.0
     checkdeps == 0.9.0
     flake8 == 7.0.0
-    mypy == 1.8.0
+    pyright == 1.1.365
     tox == 4.12.1
     twine == 4.0.2
     ufmt == 2.5.1


### PR DESCRIPTION
Fix the type annotations on `TraceOutput.__init__` to allow passing in `file=None`